### PR TITLE
Update Bluespawn.md for page-footer nav links

### DIFF
--- a/IntroClassFiles/Tools/IntroClass/bluespawn/Bluespawn.md
+++ b/IntroClassFiles/Tools/IntroClass/bluespawn/Bluespawn.md
@@ -163,3 +163,30 @@ meterpreter >`getsystem`
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+***
+***Continuing on to the next Lab?***
+
+[Click here to get back to the Navigation Menu](/IntroClassFiles/navigation.md)
+
+***Finished with the Labs?***
+
+
+Please be sure to destroy the lab environment!
+
+[Click here for instructions on how to destroy the Lab Environment](/IntroClassFiles/Tools/IntroClass/LabDestruction/labdestruction.md)
+
+---


### PR DESCRIPTION
Added the footer content for taking students/readers back to the navigation pages, directly copied from end of the Nmap.md file.

This was noted on Discord in a comment tagging @strandjs by Brian and originally by me, @siriciryel/Aisling nic Lynne